### PR TITLE
withdrawal notification wallet

### DIFF
--- a/psychic_contracts/Clarinet.toml
+++ b/psychic_contracts/Clarinet.toml
@@ -19,6 +19,11 @@ epoch = 2.5
 path = 'contracts/vote_audit_trail.clar'
 clarity_version = 2
 epoch = 2.5
+
+[contracts.withdrawal_notification_wallet]
+path = 'contracts/withdrawal_notification_wallet.clar'
+clarity_version = 2
+epoch = 2.5
 [repl.analysis]
 passes = ['check_checker']
 

--- a/psychic_contracts/contracts/withdrawal_notification_wallet.clar
+++ b/psychic_contracts/contracts/withdrawal_notification_wallet.clar
@@ -1,0 +1,122 @@
+;; Withdrawal Notification Wallet Smart Contract
+;; Emits events/logs on withdrawal operations
+
+;; Define constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-insufficient-balance (err u101))
+(define-constant err-invalid-amount (err u102))
+
+;; Define data variables
+(define-data-var wallet-balance uint u0)
+
+;; Define maps to track user balances (if supporting multiple users)
+(define-map user-balances principal uint)
+
+;; Event/Log structure for withdrawals
+;; Clarity uses print statements to emit events that can be observed off-chain
+(define-private (emit-withdrawal-event (recipient principal) (amount uint))
+  (print {
+    event: "withdrawal",
+    recipient: recipient,
+    amount: amount,
+    block-height: block-height
+  })
+)
+
+;; Initialize wallet with some balance (for testing purposes)
+(define-public (initialize-wallet (initial-balance uint))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (var-set wallet-balance initial-balance)
+    (ok initial-balance)
+  )
+)
+
+;; Deposit function to add funds to the wallet
+(define-public (deposit (amount uint))
+  (begin
+    (asserts! (> amount u0) err-invalid-amount)
+    (let ((current-balance (var-get wallet-balance)))
+      (var-set wallet-balance (+ current-balance amount))
+      (map-set user-balances tx-sender (+ (default-to u0 (map-get? user-balances tx-sender)) amount))
+      (ok (var-get wallet-balance))
+    )
+  )
+)
+
+;; Main withdrawal function that triggers event
+(define-public (withdraw (amount uint))
+  (let (
+    (current-balance (var-get wallet-balance))
+    (user-balance (default-to u0 (map-get? user-balances tx-sender)))
+  )
+    ;; Validate withdrawal conditions
+    (asserts! (> amount u0) err-invalid-amount)
+    (asserts! (>= current-balance amount) err-insufficient-balance)
+    (asserts! (>= user-balance amount) err-insufficient-balance)
+    
+    ;; Update balances
+    (var-set wallet-balance (- current-balance amount))
+    (map-set user-balances tx-sender (- user-balance amount))
+    
+    ;; Emit withdrawal event
+    (emit-withdrawal-event tx-sender amount)
+    
+    ;; Return success with remaining balance
+    (ok {
+      withdrawn-amount: amount,
+      remaining-balance: (- current-balance amount),
+      recipient: tx-sender
+    })
+  )
+)
+
+;; Owner-only withdrawal function
+(define-public (owner-withdraw (amount uint) (recipient principal))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (asserts! (> amount u0) err-invalid-amount)
+    (asserts! (>= (var-get wallet-balance) amount) err-insufficient-balance)
+    
+    ;; Update balance
+    (var-set wallet-balance (- (var-get wallet-balance) amount))
+    
+    ;; Emit withdrawal event
+    (emit-withdrawal-event recipient amount)
+    
+    ;; Return success
+    (ok {
+      withdrawn-amount: amount,
+      remaining-balance: (var-get wallet-balance),
+      recipient: recipient
+    })
+  )
+)
+
+;; Read-only functions for querying state
+(define-read-only (get-wallet-balance)
+  (var-get wallet-balance)
+)
+
+(define-read-only (get-user-balance (user principal))
+  (default-to u0 (map-get? user-balances user))
+)
+
+(define-read-only (get-contract-owner)
+  contract-owner
+)
+
+;; Helper function to check if user can withdraw amount
+(define-read-only (can-withdraw (user principal) (amount uint))
+  (let (
+    (user-balance (default-to u0 (map-get? user-balances user)))
+    (current-wallet-balance (var-get wallet-balance))
+  )
+    (and 
+      (>= user-balance amount)
+      (>= current-wallet-balance amount)
+      (> amount u0)
+    )
+  )
+)

--- a/psychic_contracts/tests/withdrawal_notification_wallet.test.ts
+++ b/psychic_contracts/tests/withdrawal_notification_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
---

# 💸 Withdrawal Notification Wallet Smart Contract

This smart contract is written in [[Clarity](https://docs.stacks.co)](https://docs.stacks.co), designed to manage a simple wallet that supports deposits, withdrawals, and emits **events/logs** whenever withdrawals occur.

It supports both **multi-user deposits/withdrawals** and **owner-only withdrawals**, making it suitable for transparent wallet management systems.

---

## 🚀 Features

* **Deposits**: Any user can deposit STX (represented as uint values in contract state).
* **Withdrawals**:

  * Regular users can withdraw their own funds (up to their balance).
  * The contract owner can withdraw funds on behalf of others.
* **Event Logging**: Withdrawals emit structured logs that can be observed off-chain.
* **Balance Tracking**:

  * Tracks overall wallet balance.
  * Tracks individual user balances.
* **Read-Only Queries** for wallet balance, user balances, contract owner, and withdrawal eligibility.

---

## ⚙️ Contract Functions

### 🔹 Initialization

* **`(initialize-wallet (initial-balance uint))`**
  Owner-only function to set the wallet’s starting balance.

---

### 🔹 Deposits

* **`(deposit (amount uint))`**
  Deposit funds into the wallet. Updates both global and user balances.

---

### 🔹 Withdrawals

* **`(withdraw (amount uint))`**
  Allows users to withdraw funds they own.
  Emits an event:

  ```clarity
  {
    event: "withdrawal",
    recipient: tx-sender,
    amount: amount,
    block-height: block-height
  }
  ```

* **`(owner-withdraw (amount uint) (recipient principal))`**
  Owner-only withdrawal function. Can send funds to any recipient. Emits an event.

---

### 🔹 Read-Only Functions

* **`(get-wallet-balance)`** → Returns total wallet balance.
* **`(get-user-balance (user principal))`** → Returns a specific user’s balance.
* **`(get-contract-owner)`** → Returns the contract owner’s principal.
* **`(can-withdraw (user principal) (amount uint))`** → Checks if a withdrawal is possible.

---

## ❌ Errors

The contract defines standard error codes:

* **`u100`** → Owner-only operation.
* **`u101`** → Insufficient balance.
* **`u102`** → Invalid amount (must be > 0).

---

## 📊 Example Usage

### Deposit

```clarity
(contract-call? .wallet deposit u100)
```

### Withdraw

```clarity
(contract-call? .wallet withdraw u50)
```

### Owner Withdraw

```clarity
(contract-call? .wallet owner-withdraw u200 'SP3FBR2AGK6X9QG5Q9M5Z2Y10KZ0Q0C5HQ2B3)
```

### Query Balances

```clarity
(contract-call? .wallet get-wallet-balance)
(contract-call? .wallet get-user-balance 'SP3FBR2AGK6X9QG5Q9M5Z2Y10KZ0Q0C5HQ2B3)
```

---

## 🏗️ Deployment Notes

* The first deployment sets the **contract owner** to the deployer (`tx-sender`).
* Use `initialize-wallet` to bootstrap balance (optional).
* Ensure off-chain indexers or apps listen for the printed **withdrawal events**.

---
