### PR TITLE
Multi-Send with Payment Splitting Smart Contract (STX)

### DIFF
--- a/psychic_contracts/Clarinet.toml
+++ b/psychic_contracts/Clarinet.toml
@@ -10,6 +10,11 @@ path = 'contracts/file_tag_moderation.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.multi_send_with_payment_splitting]
+path = 'contracts/multi_send_with_payment_splitting.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.value_locking]
 path = 'contracts/value_locking.clar'
 clarity_version = 2

--- a/psychic_contracts/contracts/multi_send_with_payment_splitting.clar
+++ b/psychic_contracts/contracts/multi_send_with_payment_splitting.clar
@@ -1,0 +1,154 @@
+;; Multi-Send Payment Splitter Contract
+;; Automatically splits incoming payments among multiple recipients based on shares
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-invalid-shares (err u101))
+(define-constant err-no-recipients (err u102))
+(define-constant err-transfer-failed (err u103))
+(define-constant err-recipient-not-found (err u104))
+(define-constant err-invalid-amount (err u105))
+(define-constant err-insufficient-balance (err u106))
+
+;; Data Variables
+(define-data-var total-shares uint u0)
+(define-data-var recipient-count uint u0)
+
+;; Data Maps
+(define-map recipients principal uint)
+(define-map recipient-index uint principal)
+
+;; Private Functions
+(define-private (calculate-share (amount uint) (shares uint))
+  (/ (* amount shares) (var-get total-shares)))
+
+(define-private (distribute-to-recipient (recipient-data {index: uint, amount: uint}) (prev-result (response bool uint)))
+  (match prev-result
+    success-value
+    (let ((index (get index recipient-data))
+          (amount (get amount recipient-data))
+          (recipient-opt (map-get? recipient-index index)))
+      (match recipient-opt
+        recipient-principal
+        (let ((shares (default-to u0 (map-get? recipients recipient-principal))))
+          (if (> shares u0)
+            (let ((share-amount (calculate-share amount shares)))
+              (match (as-contract (stx-transfer? share-amount tx-sender recipient-principal))
+                success (ok true)
+                error err-transfer-failed))
+            (ok true)))
+        (ok true)))
+    error-value (err error-value)))
+
+;; Public Functions
+
+;; Add a recipient with their share allocation
+(define-public (add-recipient (recipient principal) (shares uint))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (asserts! (> shares u0) err-invalid-shares)
+    
+    ;; Check if recipient already exists
+    (match (map-get? recipients recipient)
+      existing-shares
+      (begin
+        ;; Update existing recipient's shares
+        (var-set total-shares (- (+ (var-get total-shares) shares) existing-shares))
+        (map-set recipients recipient shares)
+        (ok true))
+      ;; Add new recipient
+      (begin
+        (map-set recipients recipient shares)
+        (map-set recipient-index (var-get recipient-count) recipient)
+        (var-set recipient-count (+ (var-get recipient-count) u1))
+        (var-set total-shares (+ (var-get total-shares) shares))
+        (ok true)))))
+
+;; Remove a recipient
+(define-public (remove-recipient (recipient principal))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (match (map-get? recipients recipient)
+      shares
+      (begin
+        (map-delete recipients recipient)
+        (var-set total-shares (- (var-get total-shares) shares))
+        (ok true))
+      err-recipient-not-found)))
+
+;; Update recipient shares
+(define-public (update-shares (recipient principal) (new-shares uint))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (asserts! (> new-shares u0) err-invalid-shares)
+    (match (map-get? recipients recipient)
+      old-shares
+      (begin
+        (var-set total-shares (+ (- (var-get total-shares) old-shares) new-shares))
+        (map-set recipients recipient new-shares)
+        (ok true))
+      err-recipient-not-found)))
+
+;; Distribute payment to all recipients
+(define-public (distribute-payment (amount uint))
+  (let ((recipient-list (list 
+          {index: u0, amount: amount}
+          {index: u1, amount: amount}
+          {index: u2, amount: amount}
+          {index: u3, amount: amount}
+          {index: u4, amount: amount}
+          {index: u5, amount: amount}
+          {index: u6, amount: amount}
+          {index: u7, amount: amount}
+          {index: u8, amount: amount}
+          {index: u9, amount: amount})))
+    (begin
+      (asserts! (> amount u0) err-invalid-amount)
+      (asserts! (> (var-get recipient-count) u0) err-no-recipients)
+      (asserts! (>= (stx-get-balance tx-sender) amount) err-insufficient-balance)
+      
+      ;; Transfer STX to contract first
+      (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+      
+      ;; Distribute to all recipients
+      (fold distribute-to-recipient recipient-list (ok true)))))
+
+;; Multi-send to specific recipients with custom amounts
+(define-public (multi-send (send-list (list 10 {to: principal, amount: uint})))
+  (begin
+    (asserts! (> (len send-list) u0) err-no-recipients)
+    (fold multi-send-iter send-list (ok true))))
+
+(define-private (multi-send-iter (send-data {to: principal, amount: uint}) (result (response bool uint)))
+  (match result
+    success
+    (match (stx-transfer? (get amount send-data) tx-sender (get to send-data))
+      success-transfer (ok true)
+      error-transfer err-transfer-failed)
+    error (err error)))
+
+;; Read-only functions
+
+;; Get recipient shares
+(define-read-only (get-recipient-shares (recipient principal))
+  (default-to u0 (map-get? recipients recipient)))
+
+;; Get total shares
+(define-read-only (get-total-shares)
+  (var-get total-shares))
+
+;; Get recipient count
+(define-read-only (get-recipient-count)
+  (var-get recipient-count))
+
+;; Calculate what a recipient would receive from a given amount
+(define-read-only (calculate-recipient-share (recipient principal) (amount uint))
+  (let ((shares (get-recipient-shares recipient)))
+    (if (and (> shares u0) (> (var-get total-shares) u0))
+      (calculate-share amount shares)
+      u0)))
+
+;; Get recipient by index
+(define-read-only (get-recipient-by-index (index uint))
+  (map-get? recipient-index index))

--- a/psychic_contracts/tests/multi_send_with_payment_splitting.test.ts
+++ b/psychic_contracts/tests/multi_send_with_payment_splitting.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
---

# Multi-Send Payment Splitter Contract

A **Clarity smart contract** that automatically splits incoming STX payments among multiple recipients based on their assigned shares. It also supports direct multi-send payments to specific recipients.

---

## 📌 Features

* **Add / Remove Recipients**

  * Assign recipients with a share allocation.
  * Update or remove them at any time.

* **Share-Based Distribution**

  * Distribute incoming payments proportionally based on each recipient’s shares.

* **Direct Multi-Send**

  * Send STX directly to multiple recipients with custom amounts in a single transaction.

* **Read-Only Queries**

  * Fetch recipient shares, total shares, recipient count, recipient by index, and simulate share calculations.

---

## ⚙️ Contract Components

### Constants & Errors

* `contract-owner` → Deployer of the contract.
* Error codes:

  * `u100`: Owner-only access
  * `u101`: Invalid shares
  * `u102`: No recipients
  * `u103`: Transfer failed
  * `u104`: Recipient not found
  * `u105`: Invalid amount
  * `u106`: Insufficient balance

### Data Storage

* **Data Vars**:

  * `total-shares` → Total shares allocated.
  * `recipient-count` → Number of registered recipients.
* **Data Maps**:

  * `recipients (principal → uint)` → Stores each recipient’s shares.
  * `recipient-index (uint → principal)` → Maps index to recipient.

---

## 🚀 Public Functions

### Recipient Management

* `add-recipient (recipient principal, shares uint)` → Add or update a recipient’s shares.
* `remove-recipient (recipient principal)` → Remove a recipient.
* `update-shares (recipient principal, new-shares uint)` → Update a recipient’s share allocation.

### Payment Distribution

* `distribute-payment (amount uint)`

  * Transfers STX to the contract.
  * Splits the payment among all recipients according to their shares.
* `multi-send (send-list (list 10 {to: principal, amount: uint}))`

  * Directly transfers custom amounts to multiple recipients in a single call.

---

## 📖 Read-Only Functions

* `get-recipient-shares (recipient principal)` → Returns recipient’s shares.
* `get-total-shares ()` → Returns total shares.
* `get-recipient-count ()` → Returns total number of recipients.
* `calculate-recipient-share (recipient principal, amount uint)` → Simulates what a recipient would receive from a given amount.
* `get-recipient-by-index (index uint)` → Fetch recipient principal by index.

---

## 🔒 Access Control

* Only the **contract owner** can:

  * Add recipients.
  * Remove recipients.
  * Update recipient shares.

* Anyone can:

  * Distribute payments.
  * Perform multi-send.
  * Read contract state.

---

## 📜 Example Usage

### Adding a Recipient

```clarity
(contract-call? .multi-send-splitter add-recipient 'ST123... 50)
```

### Distributing Payment

```clarity
(contract-call? .multi-send-splitter distribute-payment u1000000)
```

### Multi-Send Example

```clarity
(contract-call? .multi-send-splitter multi-send 
  (list {to: 'ST123..., amount: u500000} 
        {to: 'ST456..., amount: u500000}))
```

### Checking Recipient Shares

```clarity
(contract-call? .multi-send-splitter get-recipient-shares 'ST123...)
```

---

## 📑 License

This project is licensed under the **MIT License**.

---
